### PR TITLE
Fixed admin add user form now with mandatory fields

### DIFF
--- a/app/admin_panel_forms.py
+++ b/app/admin_panel_forms.py
@@ -48,7 +48,13 @@ class UserForm(forms.ModelForm):
             "is_staff",
         ]
 
-        exclude = ["password", "password_confirm"]
+    def __init__(self, *args, **kwargs):
+        super(UserForm, self).__init__(*args, **kwargs)
+        if not self.instance.pk:
+            self.fields["username"].required = True
+            self.fields["email"].required = True
+            self.fields["password"].required = True
+            self.fields["password_confirm"].required = True
 
     def clean(self):
         cleaned_data = super().clean()


### PR DESCRIPTION
Now you can log in as a superuser and is going to show you the admin panel where you can see the total number of users and cards (with numbers for last month, week and day for both) and a link to see the list of user.

List of users:
- You can see the total number of users again.
- You have a list of users (should show the email here too or not?).
- You can add a new user and give staff or superuser powers (both can activate admin panel, but only superuser can access Django admin panel - I'm trying to find a way to not allow staff giving superuser status). 
- Clicking on the user you can see its detail, you can delete the user and/or you can edit the details (user name, email and password if wanted, if not just leave it blank - it doesn't show the existent password for privacy reasons).
- On user detail you can see the total amount of card the user have and also a list with all it's cards and details, you can delete or edit the card (title, image, likes, user, tags and date).

Do we need anything else?

NEW FILES
- app/admin_panel_forms.py 
- app/views/admin_panel.py 
- app/templates/admin/card-edit.html
- .../panel.html
- .../user-detail.html 
- .../user-edit.html
- .../user-list.html

CHANGES
App/urls.py: added paths for admin panel (line 2 + starting on 22 and on)

Views/authentication.py (line 87): changed "return redirect(request, "app/admin.html")" to "return redirect("admin_panel")"

Templates/app:
- base.html: added condition to show Admin Panel link to superusers and staff (lines 26 to 28)

- home.html: added if statement (lines 43 to 45):
	{% if selected_card.image %}
		<img src="{{ selected_card.image.url }}" alt="{{ selected_card.title }}" width="250px" />
	{% endif %}

- user-wishlist.html: added if statement (lines 15 to 17):
	{% if user_wishlist.image %}
		<img src="{{ user_wishlist.image.url }}" alt="{{ user_wishlist.title }}" width="250px" />
	{% endif %}
